### PR TITLE
To fix typo on the method `setTranferType` and test name `testAgoraEncoding_specicFK`

### DIFF
--- a/base/src/main/java/org/kin/sdk/base/KinAccountContext.kt
+++ b/base/src/main/java/org/kin/sdk/base/KinAccountContext.kt
@@ -473,7 +473,7 @@ class KinAccountContextImpl private constructor(
             destinationAccount,
             KinBinaryMemo.Builder(processingAppIdx.value)
                 .setForeignKey(listOf(invoice).toProto().sha224Hash().decode())
-                .setTranferType(type)
+                .setTransferType(type)
                 .build()
                 .toKinMemo(),
             Optional.of(invoice)

--- a/base/src/main/java/org/kin/sdk/base/models/KinBinaryMemo.kt
+++ b/base/src/main/java/org/kin/sdk/base/models/KinBinaryMemo.kt
@@ -83,7 +83,7 @@ data class KinBinaryMemo internal constructor(
         private var typeId: TransferType? = null
         private var foreignKeyBytes: ByteArray? = null
 
-        fun setTranferType(typeId: TransferType): Builder =
+        fun setTransferType(typeId: TransferType): Builder =
             also { this.typeId = typeId }
 
         fun setForeignKey(foreignKeyBytes: ByteArray): Builder =

--- a/base/src/test/kotlin/org/kin/sdk/base/KinServiceImplTest.kt
+++ b/base/src/test/kotlin/org/kin/sdk/base/KinServiceImplTest.kt
@@ -982,7 +982,7 @@ class KinServiceImplTest {
             listOf(KinPaymentItem(KinAmount(123), destinationAccount.id, Optional.of(invoice))),
             KinBinaryMemo.Builder(destinationKinAppIdx.value)
                 .setForeignKey(invoiceList.id.invoiceHash.decode())
-                .setTranferType(KinBinaryMemo.TransferType.Spend)
+                .setTransferType(KinBinaryMemo.TransferType.Spend)
                 .build()
                 .toKinMemo(),
             QuarkAmount(100)

--- a/base/src/test/kotlin/org/kin/sdk/base/models/KinBinaryMemoTest.kt
+++ b/base/src/test/kotlin/org/kin/sdk/base/models/KinBinaryMemoTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertTrue
 class KinBinaryMemoTest {
 
     @Test
-    fun testAgoraEncoding_specicFK() {
+    fun testAgoraEncoding_specificFK() {
         val agoraMemo = KinBinaryMemo.Builder(10, 1, 2)
             .setTransferType(KinBinaryMemo.TransferType.P2P)
             .setForeignKey(byteArrayOf(0xAE.toByte(), 0xFD.toByte()))

--- a/base/src/test/kotlin/org/kin/sdk/base/models/KinBinaryMemoTest.kt
+++ b/base/src/test/kotlin/org/kin/sdk/base/models/KinBinaryMemoTest.kt
@@ -14,7 +14,7 @@ class KinBinaryMemoTest {
     @Test
     fun testAgoraEncoding_specicFK() {
         val agoraMemo = KinBinaryMemo.Builder(10, 1, 2)
-            .setTranferType(KinBinaryMemo.TransferType.P2P)
+            .setTransferType(KinBinaryMemo.TransferType.P2P)
             .setForeignKey(byteArrayOf(0xAE.toByte(), 0xFD.toByte()))
             .build()
 
@@ -34,7 +34,7 @@ class KinBinaryMemoTest {
         (0..500).forEach {
             println("index: $it")
             val agoraMemo = KinBinaryMemo.Builder(10, 1, 2)
-                .setTranferType(KinBinaryMemo.TransferType.P2P)
+                .setTransferType(KinBinaryMemo.TransferType.P2P)
                 .setForeignKey(UUID.randomUUID().toByteArray())
                 .build()
 
@@ -67,7 +67,7 @@ class KinBinaryMemoTest {
         (0..500).forEach {
             println("index: $it")
             val agoraMemo = KinBinaryMemo.Builder(10, 1, 2)
-                .setTranferType(KinBinaryMemo.TransferType.P2P)
+                .setTransferType(KinBinaryMemo.TransferType.P2P)
                 .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
                 .build()
 
@@ -98,7 +98,7 @@ class KinBinaryMemoTest {
     fun testAgoraEncoding_appIdx_validRange() {
         (0..65535).forEach { index ->
             val agoraMemo = KinBinaryMemo.Builder(index, 3, 7)
-                .setTranferType(KinBinaryMemo.TransferType.P2P)
+                .setTransferType(KinBinaryMemo.TransferType.P2P)
                 .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
                 .build()
 
@@ -117,7 +117,7 @@ class KinBinaryMemoTest {
     @Test(expected = KinBinaryMemo.Builder.KinBinaryMemoFormatException::class)
     fun testAgoraEncoding_appIdx_invalid_tooSmall() {
         KinBinaryMemo.Builder(appIdx = -1, magicByteIndicator = 1, version = 7)
-            .setTranferType(KinBinaryMemo.TransferType.P2P)
+            .setTransferType(KinBinaryMemo.TransferType.P2P)
             .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
             .build()
     }
@@ -125,7 +125,7 @@ class KinBinaryMemoTest {
     @Test(expected = KinBinaryMemo.Builder.KinBinaryMemoFormatException::class)
     fun testAgoraEncoding_appIdx_invalid_tooLarge() {
         KinBinaryMemo.Builder(65536, 1, 2)
-            .setTranferType(KinBinaryMemo.TransferType.P2P)
+            .setTransferType(KinBinaryMemo.TransferType.P2P)
             .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
             .build()
     }
@@ -140,7 +140,7 @@ class KinBinaryMemoTest {
     @Test
     fun testAgoraEncoding_no_fk_default_0s() {
         val memo = KinBinaryMemo.Builder(123, 1, 2)
-            .setTranferType(KinBinaryMemo.TransferType.P2P)
+            .setTransferType(KinBinaryMemo.TransferType.P2P)
             .build()
 
         assertTrue {
@@ -182,7 +182,7 @@ class KinBinaryMemoTest {
     fun testAgoraEncoding_magicByteIndicator_validRange() {
         (0..3).forEach { index ->
             val agoraMemo = KinBinaryMemo.Builder(65535, index, 7)
-                .setTranferType(KinBinaryMemo.TransferType.P2P)
+                .setTransferType(KinBinaryMemo.TransferType.P2P)
                 .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
                 .build()
 
@@ -202,7 +202,7 @@ class KinBinaryMemoTest {
     @Test(expected = KinBinaryMemo.Builder.KinBinaryMemoFormatException::class)
     fun testAgoraEncoding_magicByteIndicator_invalid_tooSmall() {
         KinBinaryMemo.Builder(65535, -1, 7)
-            .setTranferType(KinBinaryMemo.TransferType.P2P)
+            .setTransferType(KinBinaryMemo.TransferType.P2P)
             .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
             .build()
     }
@@ -210,7 +210,7 @@ class KinBinaryMemoTest {
     @Test(expected = KinBinaryMemo.Builder.KinBinaryMemoFormatException::class)
     fun testAgoraEncoding_magicByteIndicator_invalid_tooLarge() {
         KinBinaryMemo.Builder(65535, 3, 8)
-            .setTranferType(KinBinaryMemo.TransferType.P2P)
+            .setTransferType(KinBinaryMemo.TransferType.P2P)
             .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
             .build()
     }
@@ -219,7 +219,7 @@ class KinBinaryMemoTest {
     fun testAgoraEncoding_version_validRange() {
         (0..7).forEach { index ->
             val agoraMemo = KinBinaryMemo.Builder(65535, 3, index)
-                .setTranferType(KinBinaryMemo.TransferType.P2P)
+                .setTransferType(KinBinaryMemo.TransferType.P2P)
                 .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
                 .build()
 
@@ -238,7 +238,7 @@ class KinBinaryMemoTest {
     @Test(expected = KinBinaryMemo.Builder.KinBinaryMemoFormatException::class)
     fun testAgoraEncoding_version_invalid_tooSmall() {
         KinBinaryMemo.Builder(65535, 3, -1)
-            .setTranferType(KinBinaryMemo.TransferType.P2P)
+            .setTransferType(KinBinaryMemo.TransferType.P2P)
             .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
             .build()
     }
@@ -246,7 +246,7 @@ class KinBinaryMemoTest {
     @Test(expected = KinBinaryMemo.Builder.KinBinaryMemoFormatException::class)
     fun testAgoraEncoding_version_invalid_tooLarge() {
         KinBinaryMemo.Builder(65535, 3, 8)
-            .setTranferType(KinBinaryMemo.TransferType.P2P)
+            .setTransferType(KinBinaryMemo.TransferType.P2P)
             .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
             .build()
     }
@@ -256,7 +256,7 @@ class KinBinaryMemoTest {
 
         fun verifyTypeId(inputTypeId: KinBinaryMemo.TransferType) {
             val agoraMemo = KinBinaryMemo.Builder(65535, 3, 7)
-                .setTranferType(inputTypeId)
+                .setTransferType(inputTypeId)
                 .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
                 .build()
 
@@ -281,7 +281,7 @@ class KinBinaryMemoTest {
     @Test(expected = KinBinaryMemo.Builder.KinBinaryMemoFormatException::class)
     fun testAgoraEncoding_typeId_invalid_tooSmall() {
         KinBinaryMemo.Builder(65535, 3, -1)
-            .setTranferType(KinBinaryMemo.TransferType.ANY(-1))
+            .setTransferType(KinBinaryMemo.TransferType.ANY(-1))
             .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
             .build()
     }
@@ -289,7 +289,7 @@ class KinBinaryMemoTest {
     @Test(expected = KinBinaryMemo.Builder.KinBinaryMemoFormatException::class)
     fun testAgoraEncoding_typeId_invalid_tooLarge() {
         KinBinaryMemo.Builder(65535, 3, 8)
-            .setTranferType(KinBinaryMemo.TransferType.ANY(32))
+            .setTransferType(KinBinaryMemo.TransferType.ANY(32))
             .setForeignKey(UUID.randomUUID().toByteArray() + UUID.randomUUID().toByteArray())
             .build()
     }

--- a/demo/viewmodel-modern/src/main/java/org/kin/sdk/demo/viewmodel/modern/ModernSendTransactionViewModel.kt
+++ b/demo/viewmodel-modern/src/main/java/org/kin/sdk/demo/viewmodel/modern/ModernSendTransactionViewModel.kt
@@ -55,7 +55,7 @@ class ModernSendTransactionViewModel(
                 KinAmount(amount),
                 KinAccount.Id(destinationAddress),
                 KinBinaryMemo.Builder(DEMO_APP_IDX.value)
-                    .setTranferType(KinBinaryMemo.TransferType.P2P)
+                    .setTransferType(KinBinaryMemo.TransferType.P2P)
                     .build()
                     .toKinMemo()
             ).then({

--- a/demo/viewmodel-modern/src/main/java/org/kin/sdk/demo/viewmodel/modern/ModernTransactionLoadTestingViewModel.kt
+++ b/demo/viewmodel-modern/src/main/java/org/kin/sdk/demo/viewmodel/modern/ModernTransactionLoadTestingViewModel.kt
@@ -44,7 +44,7 @@ class ModernTransactionLoadTestingViewModel(
             KinAmount(10),
             KinAccount.Id(destinationAddress),
             KinBinaryMemo.Builder(DemoAppConfig.DEMO_APP_IDX.value)
-                .setTranferType(KinBinaryMemo.TransferType.P2P)
+                .setTransferType(KinBinaryMemo.TransferType.P2P)
                 .build()
                 .toKinMemo()
         ).then({


### PR DESCRIPTION
Fixing typos 
1) `setTranferType` is updated to `setTransferType`
2) `testAgoraEncoding_specicFK` is updated to `testAgoraEncoding_specificFK`.