### PR TITLE
Adds agora api as a dependency to the published pom.xml

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -208,6 +208,12 @@ afterEvaluate {
                                 it
                             }
                         }.each addDep
+                        // Add api deps also
+                        configurations.api.dependencies.findAll {
+                            if (!groupsToShade.contains(it.group)) {
+                                it
+                            }
+                        }.each addDep
                         // Add flavor specific deps
                         configurations["shaded"].allDependencies.each addDep
 


### PR DESCRIPTION
The `base-shaded` version of the sdk is not working because the agora api dependency is being ignored in the publication process. 
This should include the agora api dependency (and any other dependency using api configuration) in the published pom.xml